### PR TITLE
Fix ha-icon valign

### DIFF
--- a/src/roku-card.ts
+++ b/src/roku-card.ts
@@ -137,9 +137,11 @@ export class RokuCard extends LitElement {
       ha-icon {
         cursor: pointer;
       }
-      ha-icon {
-        --mdc-icon-button-size: 64px;
+      ha-icon-button {
         --mdc-icon-size: 48px;
+      }
+      ha-icon-button ha-icon {
+        display: flex;
       }
       img {
         width: 64px;


### PR DESCRIPTION
PR https://github.com/iantrich/roku-card/pull/69 fixed the missing `ha-icon`s, but the vertical alignment was off. These CSS changes fix the vertical alignment of the icons.